### PR TITLE
Add weasel, Solidity AI Security Auditor, AuditHub, Plamen, and Nethermind AuditAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [OpenZeppelin/openzeppelin-skills](https://github.com/OpenZeppelin/openzeppelin-skills) | Secure Development Skills | Multi-Lang |
 | [Monethic/monethic-maia](https://github.com/Monethic/monethic-maia) | AI Auditor | Multi-Lang |
 | [slvDev/weasel](https://github.com/slvDev/weasel) | Solidity static analyzer you can talk to | Multi-Lang |
+| [PlamenTSV/plamen](https://github.com/PlamenTSV/plamen) | Autonomous Web3 security audit agent | Multi-Lang |
 | [hackenproof-public/skills](https://github.com/hackenproof-public/skills) | Triage Skills | Other |
 | [marchev/claudit](https://github.com/marchev/claudit) | Security Findings Skill | Other |
 | [shuvonsec/claude-bug-bounty](https://github.com/shuvonsec/claude-bug-bounty) | AI assisted bounty hunting | Other |

--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [webrainsec](https://webrainsec.io/) | AI-augmented smart contract security | Multi-Lang |
 | [Auron](https://www.auron.xyz/) | Autonomous AI security researcher | Multi-Lang |
 | [AuditHub](https://audithub.dev/) | Automated Security Scanner | Multi-Lang |
+| [Nethermind AuditAgent](https://auditagent.nethermind.io/) | AI Audit Agent | Multi-Lang |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [Archethect/sc-auditor](https://github.com/Archethect/sc-auditor) | Smart Contract Security Auditor Skill | Solidity |
 | [auditmos/skills](https://github.com/auditmos/skills) | Security Audit Skills | Solidity |
 | [zerocoolailabs/ZeroSkills](https://github.com/zerocoolailabs/ZeroSkills) | Vulnerability Detector Skill | Solidity |
+| [KannAILabs/Solidity-AI-security-auditor](https://github.com/KannAILabs/Solidity-AI-security-auditor) | AI-powered smart contract security audit tool | Solidity |
 | [Frankcastleauditor/safe-solana-builder](https://github.com/Frankcastleauditor/safe-solana-builder) | Rust Security Development Skill | Rust |
 | [sanbir/move-auditor-skills](https://github.com/sanbir/move-auditor-skills) | Move Auditor Skills | Move |
 | [pantheraudits/move-auditor](https://github.com/pantheraudits/move-auditor/) | Move Auditor | Move |
@@ -24,6 +25,7 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [0xiehnnkta/nemesis-auditor](https://github.com/0xiehnnkta/nemesis-auditor) | Security Audit Agent Skill | Multi-Lang |
 | [OpenZeppelin/openzeppelin-skills](https://github.com/OpenZeppelin/openzeppelin-skills) | Secure Development Skills | Multi-Lang |
 | [Monethic/monethic-maia](https://github.com/Monethic/monethic-maia) | AI Auditor | Multi-Lang |
+| [slvDev/weasel](https://github.com/slvDev/weasel) | Solidity static analyzer you can talk to | Multi-Lang |
 | [hackenproof-public/skills](https://github.com/hackenproof-public/skills) | Triage Skills | Other |
 | [marchev/claudit](https://github.com/marchev/claudit) | Security Findings Skill | Other |
 | [shuvonsec/claude-bug-bounty](https://github.com/shuvonsec/claude-bug-bounty) | AI assisted bounty hunting | Other |

--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [Winfunc](https://winfunc.com/) | Autonomous AI-native security audits | Multi-Lang |
 | [webrainsec](https://webrainsec.io/) | AI-augmented smart contract security | Multi-Lang |
 | [Auron](https://www.auron.xyz/) | Autonomous AI security researcher | Multi-Lang |
+| [AuditHub](https://audithub.dev/) | Automated Security Scanner | Multi-Lang |


### PR DESCRIPTION
## Summary
- Add [slvDev/weasel](https://github.com/slvDev/weasel) — Solidity static analyzer you can talk to (Multi-Lang)
- Add [KannAILabs/Solidity-AI-security-auditor](https://github.com/KannAILabs/Solidity-AI-security-auditor) — AI-powered smart contract security audit tool (Solidity)
- Add [AuditHub](https://audithub.dev/) — Automated Security Scanner (Multi-Lang) to Paid/Closed Source tools
- Add [PlamenTSV/plamen](https://github.com/PlamenTSV/plamen) — Autonomous Web3 security audit agent (Multi-Lang)
- Add [Nethermind AuditAgent](https://auditagent.nethermind.io/) — AI Audit Agent (Multi-Lang) to Paid/Closed Source tools