### PR TITLE
Add cl0wdit and Kritt.ai to security tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [shuvonsec/claude-bug-bounty](https://github.com/shuvonsec/claude-bug-bounty) | AI assisted bounty hunting | Other |
 | [han-sec/trident-fuzz-skill](https://github.com/han-sec/trident-fuzz-skill) | Fuzzing skill | Other |
 | [ZealynxSecurity/krait](https://github.com/ZealynxSecurity/krait) | AI-First Smart Contract Security Auditor | Other |
+| [galacticcouncil/cl0wdit](https://github.com/galacticcouncil/hydration-node/blob/master/.claude/skills/security_audit/SKILL.md) | Rust AI Auditor | Rust |
 
 ## Paid/Closed Source AI Security Tools
 
@@ -60,3 +61,4 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [AuditHub](https://audithub.dev/) | Automated Security Scanner | Multi-Lang |
 | [Nethermind AuditAgent](https://auditagent.nethermind.io/) | AI Audit Agent | Multi-Lang |
 | [Critikalai](https://www.critikalai.com/) | AI Security | Multi-Lang |
+| [Kritt.ai](https://kritt.ai/#about) | AI-powered Security tailored for Blockchain | Multi-Lang |


### PR DESCRIPTION
## Summary
- Added [galacticcouncil/cl0wdit](https://github.com/galacticcouncil/hydration-node/blob/master/.claude/skills/security_audit/SKILL.md) to the **Free and Open Source Tools** section (Rust AI Auditor, Rust)
- Added [Kritt.ai](https://kritt.ai/#about) to the **Paid/Closed Source** section (AI-powered Security tailored for Blockchain, Multi-Lang)