### PR TITLE
Add cca-audit-agent and drozer-lite to open source tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [BradMoonUESTC/finite-monkey-engine](https://github.com/BradMoonUESTC/finite-monkey-engine) | AI Engine for Smart Contract Audit | Multi-Lang |
 | [scabench-org/hound](https://github.com/scabench-org/hound) | Language-agnostic AI Auditor | Multi-Lang |
 | [heavyw8t/The-Judge](https://github.com/heavyw8t/The-Judge/tree/710e06a0cee1f43fc551952acce59e3c90fa2141/skill/judge) | Judging Skill | Multi-Lang |
+| [33Audits/cca-audit-agent](https://github.com/33Audits/cca-audit-agent) | Uniswap CCA Audit Agent | Multi-Lang |
+| [gdroz3r/drozer-lite](https://github.com/gdroz3r/drozer-lite) | Smart Contract Vulnerability Scanner | Multi-Lang |
 
 ## Paid/Closed Source AI Security Tools
 


### PR DESCRIPTION
Adds two open-source web3 security tools to the Free and Open Source Tools section:

- [33Audits/cca-audit-agent](https://github.com/33Audits/cca-audit-agent) — Uniswap CCA Audit Agent (Multi-Lang)
- [gdroz3r/drozer-lite](https://github.com/gdroz3r/drozer-lite) — Smart Contract Vulnerability Scanner (Multi-Lang)