### PR TITLE
Add K.I.T to open source tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [gdroz3r/drozer-lite](https://github.com/gdroz3r/drozer-lite) | Smart Contract Vulnerability Scanner | Multi-Lang |
 | [cholakovvv/foundry-poc-mainnet-fork](https://github.com/cholakovvv/foundry-poc-mainnet-fork) | Mainnet-Fork Foundry PoC Skill | Solidity |
 | [J4X-Security/K.I.T](https://github.com/J4X-Security/K.I.T) | Creates a report of already known findings | Multi-Lang |
+| [zzzuhaibmohd/solana-token-extensions-security](https://github.com/zzzuhaibmohd/solana-token-extensions-security) | Solana Audit Skill (Token-2022) | Solana |
 
 ## Paid/Closed Source AI Security Tools
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [33Audits/cca-audit-agent](https://github.com/33Audits/cca-audit-agent) | Uniswap CCA Audit Agent | Multi-Lang |
 | [gdroz3r/drozer-lite](https://github.com/gdroz3r/drozer-lite) | Smart Contract Vulnerability Scanner | Multi-Lang |
 | [cholakovvv/foundry-poc-mainnet-fork](https://github.com/cholakovvv/foundry-poc-mainnet-fork) | Mainnet-Fork Foundry PoC Skill | Solidity |
+| [J4X-Security/K.I.T](https://github.com/J4X-Security/K.I.T) | Creates a report of already known findings | Multi-Lang |
 
 ## Paid/Closed Source AI Security Tools
 


### PR DESCRIPTION
## Summary
- Adds [J4X-Security/K.I.T](https://github.com/J4X-Security/K.I.T) to the Free and Open Source Tools list.
- Type: Creates a report of already known findings
- Technology: Multi-Lang

## Test plan
- [x] Entry matches the existing table layout and was appended after the most recent open-source row
- [x] Repo URL resolves to a public README describing the Known Issue Triager skill
