### PR TITLE
Add RASHMOR1/dlt-auditor (DLT Audit Skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Built and maintained by [www.pashov.com](https://pashov.com)
 | [cholakovvv/foundry-poc-mainnet-fork](https://github.com/cholakovvv/foundry-poc-mainnet-fork) | Mainnet-Fork Foundry PoC Skill | Solidity |
 | [J4X-Security/K.I.T](https://github.com/J4X-Security/K.I.T) | Creates a report of already known findings | Multi-Lang |
 | [zzzuhaibmohd/solana-token-extensions-security](https://github.com/zzzuhaibmohd/solana-token-extensions-security) | Solana Audit Skill (Token-2022) | Solana |
+| [RASHMOR1/dlt-auditor](https://github.com/RASHMOR1/dlt-auditor) | DLT Audit Skill | DLT |
 
 ## Paid/Closed Source AI Security Tools
 


### PR DESCRIPTION
Adds [RASHMOR1/dlt-auditor](https://github.com/RASHMOR1/dlt-auditor) to the **Free and Open Source Tools** table.

- **Tool:** RASHMOR1/dlt-auditor
- **Type:** DLT Audit Skill
- **Technology:** DLT

DLT Auditor is a free, open-source runtime audit orchestration tool that runs trained, specialized prompt-pack designs against target DLT repositories. Each design is tuned toward a different project family, competition style, or vulnerability class, and is backed by a dedicated corpus of historical DLT security fixes used to generate search patterns and hypotheses.