### PR TITLE
Add One Dollar Audit to Paid & Closed Source / Solidity / EVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 - 💼 **Want a managed platform or service?** → [Paid & Closed Source](#paid--closed-source)
 - 🔤 **Looking for your language?** → jump straight from the Contents below.
 
-![tools](https://img.shields.io/badge/tools-73-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
+![tools](https://img.shields.io/badge/tools-74-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
 
 ## Contents
 
 **Free & Open Source** — [Solidity / EVM (14)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [Multi-Language (23)](#multi-language)
 
-**Paid & Closed Source** — [Solidity / EVM (7)](#solidity--evm-1) · [Multi-Language (22)](#multi-language-1)
+**Paid & Closed Source** — [Solidity / EVM (8)](#solidity--evm-1) · [Multi-Language (22)](#multi-language-1)
 
 ---
 
@@ -101,6 +101,7 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 | [AuditBase](https://www.auditbase.com/) | Smart-contract scanner |
 | [Firepan](https://firepan.com/) | Security orchestration platform |
 | [Octane](https://www.octane.security/) | AI security engineer for Solidity/EVM |
+| [One Dollar Audit](https://www.onedollaraudit.com/) | AI Solidity audit report for a flat $1 |
 | [Solarizer](https://solarizer.io/) | AI security engine |
 | [SolidityScan](https://solidityscan.com/) | Smart-contract scanning tool |
 | [Veritas Protocol](https://www.veritasprotocol.com/) | AI security protocol |


### PR DESCRIPTION
Adds [One Dollar Audit](https://www.onedollaraudit.com/) to **Paid & Closed Source → Solidity / EVM**.

An AI auditor reviews a Solidity contract for vulnerabilities, logic errors, and access-control failures and files a written report with severity ratings — for a flat $1 fee (payable in USDC/ETH), with on-chain escrow and public review tracking.

**Changes**
- New row inserted alphabetically (between Octane and Solarizer)
- Paid / Solidity / EVM count 7 → 8 in the Contents nav
- Tools badge 73 → 74

🤖 Generated with [Claude Code](https://claude.com/claude-code)