### PR TITLE
Add TNT House Risk-Data API (Rust/Solana)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 | [Veritas Protocol](https://www.veritasprotocol.com/) | AI security protocol |
 | [Zellic V12](https://v12.zellic.io/) | Autonomous EVM auditor |
 
+### Rust / Solana
+
+| Tool | What it does |
+|------|--------------|
+| [TNT House Risk-Data API](https://www.tnt-audit.com/risk-api) | Solana token risk scoring & on-chain insider-cluster detection API for AI trading agents |
+
 ### Multi-Language
 
 <details>


### PR DESCRIPTION
Adds a new Rust / Solana subsection to Paid & Closed Source with the TNT House Risk-Data API — a Solana token risk-scoring API with on-chain-provable insider wallet cluster detection, built specifically for AI trading agents.

Free tier available (15 req/day, no card). Docs: https://www.tnt-audit.com/risk-api