### PR TITLE
Add CertiK AI Auditor (Paid & Closed Source / Multi-Language)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 - 💼 **Want a managed platform or service?** → [Paid & Closed Source](#paid--closed-source)
 - 🔤 **Looking for your language?** → jump straight from the Contents below.
 
-![tools](https://img.shields.io/badge/tools-75-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
+![tools](https://img.shields.io/badge/tools-76-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
 
 ## Contents
 
 **Free & Open Source** — [Solidity / EVM (14)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [Multi-Language (24)](#multi-language)
 
-**Paid & Closed Source** — [Solidity / EVM (8)](#solidity--evm-1) · [Multi-Language (22)](#multi-language-1)
+**Paid & Closed Source** — [Solidity / EVM (8)](#solidity--evm-1) · [Multi-Language (23)](#multi-language-1)
 
 ---
 
@@ -111,7 +111,7 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 ### Multi-Language
 
 <details>
-<summary><b>22 tools</b> — click to expand</summary>
+<summary><b>23 tools</b> — click to expand</summary>
 
 | Tool | What it does |
 |------|--------------|
@@ -121,6 +121,7 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 | [Bunzz](https://www.bunzz.dev/audit) | AI smart-contract audits |
 | [Cantina Apex](https://cantina.xyz/solutions/code-analyzer/enterprise) | Enterprise AI code analyzer |
 | [Cecuro](https://cecuro.ai/) | AI smart-contract auditing platform |
+| [CertiK AI Auditor](https://aiauditor.certik.com/) | AI auditor for Solidity, Move and Solana Rust |
 | [ChainGPT Auditor](https://www.chaingpt.org/smart-contract-auditor) | AI smart-contract auditor |
 | [Critikalai](https://www.critikalai.com/) | AI security analysis |
 | [GregoAI](https://grego.ai/) | AI security platform |


### PR DESCRIPTION
Adds [CertiK AI Auditor](https://aiauditor.certik.com/) under **Paid & Closed Source → Multi-Language**.

- **Tool name and link:** CertiK AI Auditor — https://aiauditor.certik.com/
- **What it does:** AI smart-contract auditor covering Solidity, Move and Solana Rust. Built as CertiK's internal auditor tooling before public release; positioned for baseline detection, pre-audit triage and ongoing monitoring.
- **Category:** Multi-language, paid and closed source.

Counters updated to match: tools badge 75 → 76, Contents `Multi-Language (22)` → `(23)`, and the section's `<summary>` 22 → 23 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)