### PR TITLE
Add zksecurity/zk-skills (ZK / Circom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 - 💼 **Want a managed platform or service?** → [Paid & Closed Source](#paid--closed-source)
 - 🔤 **Looking for your language?** → jump straight from the Contents below.
 
-![tools](https://img.shields.io/badge/tools-76-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
+![tools](https://img.shields.io/badge/tools-77-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
 
 ## Contents
 
-**Free & Open Source** — [Solidity / EVM (15)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [Multi-Language (24)](#multi-language)
+**Free & Open Source** — [Solidity / EVM (15)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [ZK / Circom (1)](#zk--circom) · [Multi-Language (24)](#multi-language)
 
 **Paid & Closed Source** — [Solidity / EVM (8)](#solidity--evm-1) · [Multi-Language (23)](#multi-language-1)
 
@@ -57,6 +57,12 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 | [kaveyjoe/SUIZERO](https://github.com/kaveyjoe/SUIZERO) | AI security audits for Sui Move |
 | [pantheraudits/move-auditor](https://github.com/pantheraudits/move-auditor/) | Move smart-contract auditor |
 | [sanbir/move-auditor-skills](https://github.com/sanbir/move-auditor-skills) | Audit skills for Move contracts |
+
+### ZK / Circom
+
+| Tool | What it does |
+|------|--------------|
+| [zksecurity/zk-skills](https://github.com/zksecurity/zk-skills) | Soundness, completeness and constraint review of Circom circuits |
 
 ### Multi-Language
 


### PR DESCRIPTION
Adds [zksecurity/zk-skills](https://github.com/zksecurity/zk-skills) — zkSecurity's open-source skill for auditing Circom circuits. Its `circom-auditor` skill does soundness, completeness, privacy and constraint review, in SKILL.md format, MIT licensed.

It does not fit Solidity/EVM, Rust/Solana or Move/Sui, and it is single-language, so Multi-Language would be misleading. I put it in a new **ZK / Circom** section under Free & Open Source.

Changes:
- new `### ZK / Circom` section with the one entry
- Contents line updated
- tool count badge 76 → 77

If you would rather not open a section for a single entry, say so and I will move it into Multi-Language instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)