### PR TITLE
Add 0xsimao/0xsimao-ai (Solidity / EVM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 - 💼 **Want a managed platform or service?** → [Paid & Closed Source](#paid--closed-source)
 - 🔤 **Looking for your language?** → jump straight from the Contents below.
 
-![tools](https://img.shields.io/badge/tools-77-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
+![tools](https://img.shields.io/badge/tools-78-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
 
 ## Contents
 
-**Free & Open Source** — [Solidity / EVM (15)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [ZK / Circom (1)](#zk--circom) · [Multi-Language (24)](#multi-language)
+**Free & Open Source** — [Solidity / EVM (16)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [ZK / Circom (1)](#zk--circom) · [Multi-Language (24)](#multi-language)
 
 **Paid & Closed Source** — [Solidity / EVM (8)](#solidity--evm-1) · [Multi-Language (23)](#multi-language-1)
 
@@ -26,6 +26,7 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 | Tool | What it does |
 |------|--------------|
 | ⭐ [pashov/skills](https://github.com/pashov/skills) | Full multi-pass Solidity audit skill |
+| [0xsimao/0xsimao-ai](https://github.com/0xsimao/0xsimao-ai) | Accounting-first Solidity audit skill, 12 parallel lenses |
 | [alt-research/SolidityGuard](https://github.com/alt-research/SolidityGuard) | Solidity/EVM smart-contract security auditor |
 | [Archethect/sc-auditor](https://github.com/Archethect/sc-auditor) | Smart-contract security auditor skill |
 | [auditmos/skills](https://github.com/auditmos/skills) | Smart-contract security audit skills |


### PR DESCRIPTION
Adds [0xsimao/0xsimao-ai](https://github.com/0xsimao/0xsimao-ai) to **Free & Open Source → Solidity / EVM**.

An accounting-first Solidity audit skill. It writes out the protocol's money map — assets, tracked totals and which functions write them, invariants, lifecycles, actor cohorts — then runs 12 parallel lenses against it (accounting-desync, share/exchange-rate, temporal-cohort, liquidation-solvency, cross-chain-state, rounding, ordering/MEV, DoS, access-trust, integration assumptions, edge states, flow completeness), dedups, and passes findings through four judge gates.

Public repo, model- and harness-agnostic (`SKILL.md` + `references/`). Also bumped the tool badge to 78 and the Solidity / EVM count to 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)