### PR TITLE
Add gebug-audit to Solidity/EVM tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 - 💼 **Want a managed platform or service?** → [Paid & Closed Source](#paid--closed-source)
 - 🔤 **Looking for your language?** → jump straight from the Contents below.
 
-![tools](https://img.shields.io/badge/tools-78-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
+![tools](https://img.shields.io/badge/tools-79-blue) ![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen) &nbsp; ⭐ = featured pick
 
 ## Contents
 
-**Free & Open Source** — [Solidity / EVM (16)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [ZK / Circom (1)](#zk--circom) · [Multi-Language (24)](#multi-language)
+**Free & Open Source** — [Solidity / EVM (17)](#solidity--evm) · [Rust / Solana (3)](#rust--solana) · [Move/Sui (4)](#movesui) · [ZK / Circom (1)](#zk--circom) · [Multi-Language (24)](#multi-language)
 
 **Paid & Closed Source** — [Solidity / EVM (8)](#solidity--evm-1) · [Multi-Language (23)](#multi-language-1)
 
@@ -40,6 +40,7 @@ A curated list of AI tools for smart-contract security. Built and maintained by 
 | [KannAILabs/Solidity-AI-security-auditor](https://github.com/KannAILabs/Solidity-AI-security-auditor) | AI-powered smart-contract audit tool |
 | [melanke/defi-spec-driven](https://github.com/melanke/defi-builder-skills/tree/main/plugins/defi-spec-driven) | DeFi protocol design with threat-modeling |
 | [quillai-network/qs_skills](https://github.com/quillai-network/qs_skills) | QuillAI security audit skills |
+| [TarasBrilian/gebug-audit](https://github.com/TarasBrilian/gebug-audit) | EVM audit workflow for Claude Code with AI-driven findings and Foundry PoC validation |
 | [zerocoolailabs/ZeroSkills](https://github.com/zerocoolailabs/ZeroSkills) | Vulnerability detector skill |
 
 ### Rust / Solana


### PR DESCRIPTION
## Summary

- Add the MIT-licensed `TarasBrilian/gebug-audit` workflow to the free and open-source Solidity/EVM catalog.
- Update the catalog and Solidity/EVM counters for the new entry.

## Problem

The first submission (#25) can no longer merge cleanly after recent catalog additions. The tool remains absent from the current `master` branch.

## Solution

Reapply the same focused catalog entry on a fresh branch from current `master`, preserving all intervening additions.

## Validation

- `git diff --check`
- Confirmed 17 Solidity/EVM table rows after the addition.
- Confirmed the linked repository is public, active, unarchived, and MIT-licensed with `gh repo view TarasBrilian/gebug-audit`.

## Risk

Documentation-only. No runtime, dependency, security, or compatibility impact.

Supersedes #25 at the maintainer's request.
